### PR TITLE
Fix release.yml workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - 'snapshot/**'
 
+permissions:
+  contents: write # to publish artifacts
+
 jobs:
   github_release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -25,6 +28,7 @@ jobs:
       run: |
         sbt "project pubsub; set assembly / test := {}; assembly" \
             "project kinesis; set assembly / test := {}; assembly" \
+            "project eventbridge; set assembly / test := {}; assembly" \
             "project kafka; set assembly / test := {}; assembly" \
             "project nsq; set assembly / test := {}; assembly"
     - name: Create GitHub release and attach artifacts
@@ -37,6 +41,7 @@ jobs:
         files: |
           modules/pubsub/target/scala-2.12/opensnowcat-enrich-pubsub-${{ steps.ver.outputs.tag }}.jar
           modules/kinesis/target/scala-2.12/opensnowcat-enrich-kinesis-${{ steps.ver.outputs.tag }}.jar
+          modules/eventbridge/target/scala-2.12/opensnowcat-enrich-eventbridge-${{ steps.ver.outputs.tag }}.jar
           modules/kafka/target/scala-2.12/opensnowcat-enrich-kafka-${{ steps.ver.outputs.tag }}.jar
           modules/nsq/target/scala-2.12/opensnowcat-enrich-nsq-${{ steps.ver.outputs.tag }}.jar
       env:
@@ -50,10 +55,13 @@ jobs:
         app:
           - pubsub
           - kinesis
+          - eventbridge
           - kafka
           - nsq
         include:
           - app: kinesis
+            run_snyk: ${{ !contains(github.ref, 'rc') }}
+          - app: eventbridge
             run_snyk: ${{ !contains(github.ref, 'rc') }}
           - app: pubsub
             run_snyk: ${{ !contains(github.ref, 'rc') }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ project/boot/
 project/plugins/project/
 
 .bsp
+.idea/


### PR DESCRIPTION
We need to explicitly set the write permission to the workflow so that the action can publish artifacts.

Also, include the eventbridge jar in the published artifacts, and, ignore ".idea/" directory.
