### PR TITLE
Refactor the process to produce JSON output

### DIFF
--- a/config/config.eventbridge.extended.hocon
+++ b/config/config.eventbridge.extended.hocon
@@ -362,5 +362,18 @@
       "organizationId": "c5f3a09f-75f8-4309-bec5-fea560f78455"
       "pipelineId": "75a13583-5c99-40e3-81fc-541084dfc784"
     }
+
+    # Whether to use an alternative output format  (either "FlattenedJson" or "EventbridgeJson")
+    # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
+    # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
+    "customOutputFormat": {
+      "type": "EventbridgeJson"
+
+      # Add a "payload" parameter with the original base64 encoded TSV. Defaults to false (Useful for EventbridgeJson only).
+      "payload": true
+
+      # Add a "collector" parameter from contexts_org_ietf_http_header_1 Host Value. Defaults to false (Useful for EventbridgeJson only).
+      "collector": true
+    }
   }
 }

--- a/config/config.eventbridge.minimal.hocon
+++ b/config/config.eventbridge.minimal.hocon
@@ -28,4 +28,12 @@
       "byteLimit": 250000
     }
   }
+
+  "experimental": {
+    "customOutputFormat": {
+      "type": "EventbridgeJson"
+      "payload": true
+      "collector": true
+    }
+  }
 }

--- a/config/config.file.extended.hocon
+++ b/config/config.file.extended.hocon
@@ -151,4 +151,14 @@
     # Try to base64 decode event if initial Thrift serialization fail
     "tryBase64Decoding": false
   }
+
+  # Optional. Configuration for experimental/preview features
+  # "experimental": {
+    # Whether to use an alternative output format  (either "FlattenedJson" or "EventbridgeJson")
+    # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
+    # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
+    # "customOutputFormat": {
+    #   "type": "FlattenedJson"
+    # }
+  # }
 }

--- a/config/config.kafka.extended.hocon
+++ b/config/config.kafka.extended.hocon
@@ -258,5 +258,12 @@
       "organizationId": "c5f3a09f-75f8-4309-bec5-fea560f78455"
       "pipelineId": "75a13583-5c99-40e3-81fc-541084dfc784"
     }
+
+    # Whether to use an alternative output format  (either "FlattenedJson" or "EventbridgeJson")
+    # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
+    # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
+    # "customOutputFormat": {
+    #   "type": "FlattenedJson"
+    # }
   }
 }

--- a/config/config.kinesis.extended.hocon
+++ b/config/config.kinesis.extended.hocon
@@ -369,5 +369,12 @@
       "organizationId": "c5f3a09f-75f8-4309-bec5-fea560f78455"
       "pipelineId": "75a13583-5c99-40e3-81fc-541084dfc784"
     }
+
+    # Whether to use an alternative output format  (either "FlattenedJson" or "EventbridgeJson")
+    # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
+    # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
+    # "customOutputFormat": {
+    #   "type": "FlattenedJson"
+    # }
   }
 }

--- a/config/config.kinesis.extended.hocon
+++ b/config/config.kinesis.extended.hocon
@@ -116,9 +116,6 @@
       # Optional. Use a custom Kinesis endpoint.
       # Can be used for instance to work locally with localstack
       # "customEndpoint": "https://localhost:4566"
-
-      # Encode the output as json, by default, output is encoded as TSV.
-      "jsonOutput": false
     }
 
     # Pii events output
@@ -169,9 +166,6 @@
       # Optional. Use a custom Kinesis endpoint.
       # Can be used for instance to work locally with localstack
       # "customEndpoint": "https://localhost:4566"
-
-      # Encode the output as json, by default, output is encoded as TSV.
-      "jsonOutput": false
     }
 
     # Bad rows output
@@ -214,9 +208,6 @@
       # Optional. Use a custom Kinesis endpoint.
       # Can be used for instance to work locally with localstack
       # "customEndpoint": "https://localhost:4566"
-
-      # Encode the output as json, by default, output is encoded as TSV.
-      "jsonOutput": false
     }
   }
 

--- a/config/config.nsq.extended.hocon
+++ b/config/config.nsq.extended.hocon
@@ -260,5 +260,12 @@
       "organizationId": "c5f3a09f-75f8-4309-bec5-fea560f78455"
       "pipelineId": "75a13583-5c99-40e3-81fc-541084dfc784"
     }
+
+    # Whether to use an alternative output format  (either "FlattenedJson" or "EventbridgeJson")
+    # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
+    # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
+    # "customOutputFormat": {
+    #   "type": "FlattenedJson"
+    # }
   }
 }

--- a/config/config.pubsub.extended.hocon
+++ b/config/config.pubsub.extended.hocon
@@ -256,5 +256,12 @@
       "organizationId": "c5f3a09f-75f8-4309-bec5-fea560f78455"
       "pipelineId": "75a13583-5c99-40e3-81fc-541084dfc784"
     }
+
+    # Whether to use an alternative output format  (either "FlattenedJson" or "EventbridgeJson")
+    # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
+    # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
+    # "customOutputFormat": {
+    #   "type": "FlattenedJson"
+    # }
   }
 }

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Enrich.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Enrich.scala
@@ -300,10 +300,7 @@ object Enrich {
             val badRow = BadRow.GenericError(
               processor = processor,
               failure = Failure.GenericFailure(Instant.now(), NonEmptyList(error.toString, List.empty)),
-              // TODO: should we trim the payload like we do for normal output?
-              payload = BadRowPayload.RawPayload(
-                base64TSV // .take(maxRecordSize * 8 / 10)
-              )
+              payload = BadRowPayload.RawPayload(base64TSV)
             )
             Left(badRow)
 
@@ -321,7 +318,6 @@ object Enrich {
         val msg = s"event passed enrichment but then exceeded the maximum allowed size $maxRecordSize bytes"
         val payload = customOutputFormat match {
           case None => BadRowPayload.RawPayload(asStr.take(maxRecordSize * 8 / 10))
-          // TODO: on json outputs, we return the TSV, should we trim this?
           case Some(_) => BadRowPayload.RawPayload(base64TSV)
         }
 

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Environment.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Environment.scala
@@ -40,11 +40,11 @@ import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegist
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 import com.snowplowanalytics.snowplow.enrich.common.utils.{HttpClient, ShiftExecution}
-
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.{ConfigFile, ParsedConfigs}
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.{
   Cloud,
   Concurrency,
+  CustomOutputFormat,
   FeatureFlags,
   RemoteAdapterConfigs,
   Telemetry => TelemetryConfig
@@ -125,7 +125,8 @@ final case class Environment[F[_], A](
   streamsSettings: Environment.StreamsSettings,
   region: Option[String],
   cloud: Option[Cloud],
-  featureFlags: FeatureFlags
+  featureFlags: FeatureFlags,
+  customOutputFormat: Option[CustomOutputFormat]
 )
 
 object Environment {
@@ -239,7 +240,8 @@ object Environment {
       StreamsSettings(file.concurrency, maxRecordSize),
       getRegionFromConfig(file).orElse(getRegion),
       cloud,
-      featureFlags
+      featureFlags,
+      file.experimental.flatMap(_.customOutputFormat)
     )
   }
 

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ParsedConfigs.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ParsedConfigs.scala
@@ -130,7 +130,7 @@ object ParsedConfigs {
             if (invalidAttributes.nonEmpty) NonEmptyList(invalidAttributes.head, invalidAttributes.tail.toList).invalid
             else output.valid
           }
-      case OutputConfig.Kinesis(_, _, Some(key), _, _, _, _, _, _) if !enrichedFieldsMap.contains(key) =>
+      case OutputConfig.Kinesis(_, _, Some(key), _, _, _, _, _) if !enrichedFieldsMap.contains(key) =>
         NonEmptyList.one(s"Partition key $key not valid").invalid
       case ka: OutputConfig.Kafka if !ka.headers.forall(enrichedFieldsMap.contains) =>
         NonEmptyList
@@ -162,7 +162,7 @@ object ParsedConfigs {
   private[config] def outputPartitionKey(output: OutputConfig): EnrichedEvent => String =
     output match {
       case OutputConfig.Kafka(_, _, partitionKey, _, _) => partitionKeyFromFields(partitionKey)
-      case OutputConfig.Kinesis(_, _, Some(partitionKey), _, _, _, _, _, _) => partitionKeyFromFields(partitionKey)
+      case OutputConfig.Kinesis(_, _, Some(partitionKey), _, _, _, _, _) => partitionKeyFromFields(partitionKey)
       case _ => _ => UUID.randomUUID().toString
     }
 

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
@@ -275,8 +275,7 @@ object io {
       throttledBackoffPolicy: BackoffPolicy,
       recordLimit: Int,
       byteLimit: Int,
-      customEndpoint: Option[URI],
-      jsonOutput: Boolean
+      customEndpoint: Option[URI]
     ) extends Output
 
     case class Eventbridge(
@@ -287,9 +286,7 @@ object io {
       throttledBackoffPolicy: BackoffPolicy,
       recordLimit: Int,
       byteLimit: Int,
-      customEndpoint: Option[URI],
-      collector: Option[Boolean],
-      payload: Option[Boolean]
+      customEndpoint: Option[URI]
     ) extends Output
 
     implicit val outputDecoder: Decoder[Output] =

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
@@ -482,12 +482,12 @@ object io {
     implicit val customOutputFormatDecoder: Decoder[CustomOutputFormat] =
       Decoder.instance { cur =>
         for {
-          rawParsed <- cur.as[CustomOutputFormatRaw].map(raw => raw.copy(`type` = raw.`type`.toUpperCase))
+          rawParsed <- cur.as[CustomOutputFormatRaw].map(raw => raw.copy(`type` = raw.`type`))
           customOutputFormat <- rawParsed match {
-                                  case CustomOutputFormatRaw("FLATTENED_JSON", _, _) =>
+                                  case CustomOutputFormatRaw(tpe, _, _) if tpe equalsIgnoreCase "FlattenedJson" =>
                                     FlattenedJson.asRight
 
-                                  case CustomOutputFormatRaw("EVENTBRIDGE_JSON", payloadOpt, collectorOtp) =>
+                                  case CustomOutputFormatRaw(tpe, payloadOpt, collectorOtp) if tpe equalsIgnoreCase "EventbridgeJson" =>
                                     EventbridgeJson(
                                       payload = payloadOpt.getOrElse(false),
                                       collector = collectorOtp.getOrElse(false)
@@ -495,7 +495,7 @@ object io {
 
                                   case other =>
                                     DecodingFailure(
-                                      s"Custom output format $other is not supported. Possible types are FLATTENED_JSON and EVENTBRIDGE_JSON",
+                                      s"Custom output format $other is not supported. Possible types are FlattenedJson and EventbridgeJson",
                                       cur.history
                                     ).asLeft
                                 }

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
@@ -464,7 +464,51 @@ object io {
       deriveConfiguredEncoder[Metadata]
   }
 
-  case class Experimental(metadata: Option[Metadata])
+  sealed trait CustomOutputFormat
+
+  object CustomOutputFormat {
+    final case object FlattenedJson extends CustomOutputFormat
+
+    final case class EventbridgeJson(payload: Boolean, collector: Boolean) extends CustomOutputFormat
+
+    case class CustomOutputFormatRaw(
+      `type`: String,
+      payload: Option[Boolean],
+      collector: Option[Boolean]
+    )
+
+    implicit val customOutputFormatRawDecoder: Decoder[CustomOutputFormatRaw] = deriveConfiguredDecoder[CustomOutputFormatRaw]
+
+    implicit val customOutputFormatDecoder: Decoder[CustomOutputFormat] =
+      Decoder.instance { cur =>
+        for {
+          rawParsed <- cur.as[CustomOutputFormatRaw].map(raw => raw.copy(`type` = raw.`type`.toUpperCase))
+          customOutputFormat <- rawParsed match {
+                                  case CustomOutputFormatRaw("FLATTENED_JSON", _, _) =>
+                                    FlattenedJson.asRight
+
+                                  case CustomOutputFormatRaw("EVENTBRIDGE_JSON", payloadOpt, collectorOtp) =>
+                                    EventbridgeJson(
+                                      payload = payloadOpt.getOrElse(false),
+                                      collector = collectorOtp.getOrElse(false)
+                                    ).asRight
+
+                                  case other =>
+                                    DecodingFailure(
+                                      s"Custom output format $other is not supported. Possible types are FLATTENED_JSON and EVENTBRIDGE_JSON",
+                                      cur.history
+                                    ).asLeft
+                                }
+        } yield customOutputFormat
+      }
+
+    implicit val customOutputFormatEncoder: Encoder[CustomOutputFormat] = deriveConfiguredEncoder[CustomOutputFormat]
+  }
+
+  case class Experimental(
+    metadata: Option[Metadata],
+    customOutputFormat: Option[CustomOutputFormat]
+  )
   object Experimental {
     implicit val experimentalDecoder: Decoder[Experimental] =
       deriveConfiguredDecoder[Experimental]

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/EnrichSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/EnrichSpec.scala
@@ -368,13 +368,16 @@ class EnrichSpec extends Specification with CatsIO with ScalaCheck {
     }
 
     "serialize a good event to the good output (json format)" in {
-      // TODO: Fixme
-      val ee = new EnrichedEvent()
+      val ee = new EnrichedEvent {
+        collector_tstamp = "2011-12-03T10:15:30"
+        event_id = "236392af-ffec-4def-a0de-86929e9615be"
+        v_collector = "test"
+        v_etl = "test"
+      }
 
       TestEnvironment.make(Stream.empty).use { test =>
         val env = test.env.copy(
-          customOutputFormat = Some(CustomOutputFormat.FlattenedJson),
-          streamsSettings = test.env.streamsSettings.copy(maxRecordSize = 10)
+          customOutputFormat = Some(CustomOutputFormat.FlattenedJson)
         )
         for {
           _ <- sinkGood(env, ee)
@@ -385,18 +388,24 @@ class EnrichSpec extends Specification with CatsIO with ScalaCheck {
           (good.size must_== 1)
           (bad should be empty)
           (pii should be empty)
+
+          val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
+          (jsonE.isRight should beTrue)
         }
       }
     }
 
     "serialize a good event to the good output (eventbridge format)" in {
-      // TODO: Fixme
-      val ee = new EnrichedEvent()
+      val ee = new EnrichedEvent {
+        collector_tstamp = "2011-12-03T10:15:30"
+        event_id = "236392af-ffec-4def-a0de-86929e9615be"
+        v_collector = "test"
+        v_etl = "test"
+      }
 
       TestEnvironment.make(Stream.empty).use { test =>
         val env = test.env.copy(
-          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(payload = false, collector = false)),
-          streamsSettings = test.env.streamsSettings.copy(maxRecordSize = 10)
+          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(payload = false, collector = false))
         )
         for {
           _ <- sinkGood(env, ee)
@@ -407,18 +416,24 @@ class EnrichSpec extends Specification with CatsIO with ScalaCheck {
           (good.size must_== 1)
           (bad should be empty)
           (pii should be empty)
+
+          val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
+          (jsonE.isRight should beTrue)
         }
       }
     }
 
     "serialize a good event to the good output (eventbridge format with payload)" in {
-      // TODO: Fixme
-      val ee = new EnrichedEvent()
+      val ee = new EnrichedEvent {
+        collector_tstamp = "2011-12-03T10:15:30"
+        event_id = "236392af-ffec-4def-a0de-86929e9615be"
+        v_collector = "test"
+        v_etl = "test"
+      }
 
       TestEnvironment.make(Stream.empty).use { test =>
         val env = test.env.copy(
-          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(payload = true, collector = false)),
-          streamsSettings = test.env.streamsSettings.copy(maxRecordSize = 10)
+          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(payload = true, collector = false))
         )
         for {
           _ <- sinkGood(env, ee)
@@ -429,18 +444,32 @@ class EnrichSpec extends Specification with CatsIO with ScalaCheck {
           (good.size must_== 1)
           (bad should be empty)
           (pii should be empty)
+
+          val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
+          (jsonE.isRight should beTrue)
+
+          val payloadE = jsonE.right.get.hcursor.get[String]("payload")
+          (payloadE.isRight should beTrue)
+
+          // payload is the original TSV encoded in base64
+          val tsv = ConversionUtils.tabSeparatedEnrichedEvent(ee)
+          val data = java.util.Base64.getDecoder.decode(payloadE.right.get)
+          (new String(data) must_== tsv)
         }
       }
     }
 
-    "serialize a good event to the good output (eventbridge format with collector)" in {
-      // TODO: Fixme
-      val ee = new EnrichedEvent()
+    "serialize a good event to the good output (eventbridge format with collector null)" in {
+      val ee = new EnrichedEvent {
+        collector_tstamp = "2011-12-03T10:15:30"
+        event_id = "236392af-ffec-4def-a0de-86929e9615be"
+        v_collector = "test"
+        v_etl = "test"
+      }
 
       TestEnvironment.make(Stream.empty).use { test =>
         val env = test.env.copy(
-          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(payload = false, collector = true)),
-          streamsSettings = test.env.streamsSettings.copy(maxRecordSize = 10)
+          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(payload = false, collector = true))
         )
         for {
           _ <- sinkGood(env, ee)
@@ -451,18 +480,86 @@ class EnrichSpec extends Specification with CatsIO with ScalaCheck {
           (good.size must_== 1)
           (bad should be empty)
           (pii should be empty)
+
+          val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
+          (jsonE.isRight should beTrue)
+
+          val collectorE = jsonE.right.get.hcursor.get[Option[String]]("collector")
+          (collectorE.isRight should beTrue)
+          (collectorE.right.get should beNone)
+        }
+      }
+    }
+
+    "serialize a good event to the good output (eventbridge format with collector not null)" in {
+      val httpHeaderSchema =
+        SchemaKey(
+          "org.ietf",
+          "http_header",
+          "jsonschema",
+          SchemaVer.Full(1, 0, 0)
+        )
+
+      def buildInputContexts(sdjs: List[String]) = {
+        val inputContextsSchema =
+          SchemaKey(
+            "com.snowplowanalytics.snowplow",
+            "contexts",
+            "jsonschema",
+            SchemaVer.Full(1, 0, 0)
+          )
+        s"""{"schema": "${inputContextsSchema.toSchemaUri}", "data": [${sdjs.mkString(",")}]}"""
+      }
+
+      val ee = new EnrichedEvent {
+        collector_tstamp = "2011-12-03T10:15:30"
+        event_id = "236392af-ffec-4def-a0de-86929e9615be"
+        v_collector = "test"
+        v_etl = "test"
+        contexts = buildInputContexts(List(s"""{
+            "schema": "${httpHeaderSchema.toSchemaUri}",
+            "data": {
+              "name": "Host",
+              "value": "test"
+            }
+          }"""))
+      }
+
+      TestEnvironment.make(Stream.empty).use { test =>
+        val env = test.env.copy(
+          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(payload = false, collector = true))
+        )
+        for {
+          _ <- sinkGood(env, ee)
+          good <- test.good
+          pii <- test.pii
+          bad <- test.bad
+        } yield {
+          (good.size must_== 1)
+          (bad should be empty)
+          (pii should be empty)
+
+          val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
+          (jsonE.isRight should beTrue)
+
+          val collectorE = jsonE.right.get.hcursor.get[String]("collector")
+          (collectorE.isRight should beTrue)
+          (collectorE.right.get must_== "test")
         }
       }
     }
 
     "serialize a good event to the good output (eventbridge format with payload and collector)" in {
-      // TODO: Fixme
-      val ee = new EnrichedEvent()
+      val ee = new EnrichedEvent {
+        collector_tstamp = "2011-12-03T10:15:30"
+        event_id = "236392af-ffec-4def-a0de-86929e9615be"
+        v_collector = "test"
+        v_etl = "test"
+      }
 
       TestEnvironment.make(Stream.empty).use { test =>
         val env = test.env.copy(
-          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(payload = true, collector = true)),
-          streamsSettings = test.env.streamsSettings.copy(maxRecordSize = 10)
+          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(payload = true, collector = true))
         )
         for {
           _ <- sinkGood(env, ee)
@@ -473,6 +570,17 @@ class EnrichSpec extends Specification with CatsIO with ScalaCheck {
           (good.size must_== 1)
           (bad should be empty)
           (pii should be empty)
+
+          val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
+          (jsonE.isRight should beTrue)
+
+          val collectorE = jsonE.right.get.hcursor.get[Option[String]]("collector")
+          (collectorE.isRight should beTrue)
+          (collectorE.right.get should beNone)
+
+          val payloadE = jsonE.right.get.hcursor.get[String]("payload")
+          (payloadE.isRight should beTrue)
+          (payloadE.right.get.isEmpty must beFalse)
         }
       }
     }
@@ -498,6 +606,37 @@ class EnrichSpec extends Specification with CatsIO with ScalaCheck {
       }
     }
 
+    "serialize an invalid-json event to the bad output (json format)" in {
+      // TODO: Fixme
+      val ee = new EnrichedEvent()
+      ee.app_id = "x" * 10000000
+
+      TestEnvironment.make(Stream.empty).use { test =>
+        val env = test.env.copy(
+          customOutputFormat = Some(CustomOutputFormat.FlattenedJson),
+          streamsSettings = test.env.streamsSettings.copy(maxRecordSize = 10)
+        )
+
+        for {
+          _ <- sinkGood(env, ee)
+          good <- test.good
+          pii <- test.pii
+          bad <- test.bad
+        } yield {
+          //          println(s"good: ${new String(good.head.data)}")
+          //          println(s"pii: ${new String(pii.head.data)}")
+          //          println(s"bad: ${new String(bad.head)}")
+
+          bad should beLike { case Vector(bytes) =>
+            bytes must not be empty
+            bytes must have size (be_<=(6900000))
+          }
+          (good should be empty)
+          (pii should be empty)
+        }
+      }
+    }
+
     "serialize an over-sized good event to the bad output (json format)" in {
       // TODO: Fixme
       val ee = new EnrichedEvent()
@@ -506,6 +645,37 @@ class EnrichSpec extends Specification with CatsIO with ScalaCheck {
       TestEnvironment.make(Stream.empty).use { test =>
         val env = test.env.copy(
           customOutputFormat = Some(CustomOutputFormat.FlattenedJson),
+          streamsSettings = test.env.streamsSettings.copy(maxRecordSize = 10)
+        )
+
+        for {
+          _ <- sinkGood(env, ee)
+          good <- test.good
+          pii <- test.pii
+          bad <- test.bad
+        } yield {
+          //          println(s"good: ${new String(good.head.data)}")
+          //          println(s"pii: ${new String(pii.head.data)}")
+          //          println(s"bad: ${new String(bad.head)}")
+
+          bad should beLike { case Vector(bytes) =>
+            bytes must not be empty
+            bytes must have size (be_<=(6900000))
+          }
+          (good should be empty)
+          (pii should be empty)
+        }
+      }
+    }
+
+    "serialize an invalid-json event to the bad output (eventbridge format)" in {
+      // TODO: Fixme
+      val ee = new EnrichedEvent()
+      ee.app_id = "x" * 10000000
+
+      TestEnvironment.make(Stream.empty).use { test =>
+        val env = test.env.copy(
+          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(false, false)),
           streamsSettings = test.env.streamsSettings.copy(maxRecordSize = 10)
         )
 

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ParsedConfigsSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ParsedConfigsSpec.scala
@@ -117,7 +117,8 @@ class ParsedConfigsSpec extends Specification with CatsIO {
                 UUID.fromString("c5f3a09f-75f8-4309-bec5-fea560f78455"),
                 UUID.fromString("75a13583-5c99-40e3-81fc-541084dfc784")
               )
-            )
+            ),
+            None
           )
         ),
         adaptersSchemas,

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/test/TestEnvironment.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/test/TestEnvironment.scala
@@ -162,7 +162,8 @@ object TestEnvironment extends CatsIO {
                       StreamsSettings(Concurrency(10000, 64), 1024 * 1024),
                       None,
                       None,
-                      EnrichSpec.featureFlags
+                      EnrichSpec.featureFlags,
+                      None
                     )
       _ <- Resource.eval(logger.info("TestEnvironment initialized"))
     } yield TestEnvironment(environment, counter, goodRef.get, piiRef.get, badRef.get)

--- a/modules/eventbridge/src/it/resources/enrich/enrich-localstack.hocon
+++ b/modules/eventbridge/src/it/resources/enrich/enrich-localstack.hocon
@@ -47,4 +47,12 @@
   "telemetry": {
     "disable": true
   }
+
+  "experimental": {
+    "customOutputFormat": {
+      "type": "EventbridgeJson"
+      "payload": true
+      "collector": true
+    }
+  }
 }

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/IntegrationTestConfig.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/IntegrationTestConfig.scala
@@ -48,7 +48,6 @@ object IntegrationTestConfig {
       500,
       5242880,
       Some(URI.create(getEndpoint(localstackPort))),
-      jsonOutput = false
     )
 
   def kinesisInputStreamConfig(localstackPort: Int, streamName: String) =

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/IntegrationTestConfig.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/IntegrationTestConfig.scala
@@ -34,8 +34,6 @@ object IntegrationTestConfig {
       recordLimit = 10,
       byteLimit = 100000,
       customEndpoint = Some(URI.create(getEndpoint(localstackPort))),
-      collector = None,
-      payload = None
     )
 
   def kinesisOutputStreamConfig(localstackPort: Int, streamName: String) =

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/kinesis/Sink.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/kinesis/Sink.scala
@@ -13,13 +13,10 @@
 package com.snowplowanalytics.snowplow.enrich.kinesis
 
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import scala.collection.JavaConverters._
-import scala.util.control.NonFatal
 
-import cats.data.Validated
 import cats.implicits._
 import cats.{Monoid, Parallel}
 
@@ -37,7 +34,6 @@ import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.kinesis.model._
 import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder}
 
-import com.snowplowanalytics.snowplow.analytics.scalasdk.Event
 import com.snowplowanalytics.snowplow.enrich.common.fs2.{AttributedByteSink, AttributedData, ByteSink}
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.Output
 import com.snowplowanalytics.snowplow.enrich.common.fs2.io.Retries
@@ -65,7 +61,7 @@ object Sink {
           case Some(region) =>
             for {
               producer <- Resource.eval[F, AmazonKinesis](mkProducer(o, region))
-            } yield records => writeToKinesis(blocker, o, producer, toKinesisRecords(records, o))
+            } yield records => writeToKinesis(blocker, o, producer, toKinesisRecords(records))
           case None =>
             Resource.eval(Sync[F].raiseError(new RuntimeException(s"Region not found in the config and in the runtime")))
         }
@@ -209,24 +205,9 @@ object Sink {
             result.nextBatchAttempt.pure[F]
         }
 
-  private def toKinesisRecords(records: List[AttributedData[Array[Byte]]], config: Output.Kinesis): List[PutRecordsRequestEntry] =
+  private def toKinesisRecords(records: List[AttributedData[Array[Byte]]]): List[PutRecordsRequestEntry] =
     records.map { r =>
-      val sourceData = r.data
-      val binaryData =
-        try if (config.jsonOutput) {
-          val tsv = new String(sourceData)
-          // TODO: Its likely better to handle this in the layer that validates the output size is not exceeded
-          Event.parse(tsv) match {
-            case Validated.Valid(event) => event.toJson(lossy = true).noSpaces.getBytes(StandardCharsets.UTF_8)
-            case Validated.Invalid(_) => sourceData
-          }
-        } else
-          sourceData
-        catch {
-          // TODO: Re-consider what to do when parsing the data fails
-          case NonFatal(_) => sourceData
-        }
-
+      val binaryData = r.data
       val data = ByteBuffer.wrap(binaryData)
       val prre = new PutRecordsRequestEntry()
       prre.setPartitionKey(r.partitionKey)

--- a/modules/eventbridge/src/main/resources/application.conf
+++ b/modules/eventbridge/src/main/resources/application.conf
@@ -107,4 +107,12 @@
     "gcs": false
     "s3": true
   }
+
+  "experimental": {
+    "customOutputFormat": {
+      "type": "EventbridgeJson"
+      "payload": true
+      "collector": true
+    }
+  }
 }

--- a/modules/eventbridge/src/test/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/ConfigSpec.scala
+++ b/modules/eventbridge/src/test/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/ConfigSpec.scala
@@ -58,8 +58,6 @@ class ConfigSpec extends Specification with CatsIO {
             io.BackoffPolicy(100.millis, 1.second, None),
             10,
             250000,
-            None,
-            None,
             None
           ),
           None,
@@ -71,8 +69,6 @@ class ConfigSpec extends Specification with CatsIO {
             io.BackoffPolicy(100.millis, 1.second, None),
             10,
             250000,
-            None,
-            None,
             None
           )
         ),
@@ -144,9 +140,7 @@ class ConfigSpec extends Specification with CatsIO {
             io.BackoffPolicy(100.millis, 1.second, None),
             10,
             250000,
-            None,
-            Some(true),
-            Some(true)
+            None
           ),
           Some(
             io.Output.Eventbridge(
@@ -157,9 +151,7 @@ class ConfigSpec extends Specification with CatsIO {
               io.BackoffPolicy(100.millis, 1.second, None),
               10,
               250000,
-              None,
-              Some(true),
-              Some(true)
+              None
             )
           ),
           io.Output.Eventbridge(
@@ -170,8 +162,6 @@ class ConfigSpec extends Specification with CatsIO {
             io.BackoffPolicy(100.millis, 1.second, None),
             10,
             250000,
-            None,
-            None,
             None
           )
         ),

--- a/modules/eventbridge/src/test/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/ConfigSpec.scala
+++ b/modules/eventbridge/src/test/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/ConfigSpec.scala
@@ -133,7 +133,8 @@ class ConfigSpec extends Specification with CatsIO {
                 UUID.fromString("c5f3a09f-75f8-4309-bec5-fea560f78455"),
                 UUID.fromString("75a13583-5c99-40e3-81fc-541084dfc784")
               )
-            )
+            ),
+            None
           )
         ),
         adaptersSchemas,

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/enrich/kafka/ConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/enrich/kafka/ConfigSpec.scala
@@ -117,7 +117,8 @@ class ConfigSpec extends Specification with CatsIO {
                 UUID.fromString("c5f3a09f-75f8-4309-bec5-fea560f78455"),
                 UUID.fromString("75a13583-5c99-40e3-81fc-541084dfc784")
               )
-            )
+            ),
+            None
           )
         ),
         adaptersSchemas,

--- a/modules/kinesis/src/it/scala/com/snowplowanalytics/snowplow/enrich/kinesis/KinesisConfig.scala
+++ b/modules/kinesis/src/it/scala/com/snowplowanalytics/snowplow/enrich/kinesis/KinesisConfig.scala
@@ -62,7 +62,6 @@ object KinesisConfig {
       500,
       5242880,
       Some(URI.create(getEndpoint(localstackPort))),
-      jsonOutput = false
     )
 
   val monitoring = Monitoring(

--- a/modules/kinesis/src/main/resources/application.conf
+++ b/modules/kinesis/src/main/resources/application.conf
@@ -31,7 +31,6 @@
       }
       "recordLimit": 500
       "byteLimit": 5242880
-      "jsonOutput": false
     }
 
     "pii": {
@@ -49,7 +48,6 @@
       }
       "recordLimit": 500
       "byteLimit": 5242880
-      "jsonOutput": false
     }
 
     "bad": {
@@ -65,7 +63,6 @@
       }
       "recordLimit": 500
       "byteLimit": 5242880
-      "jsonOutput": false
     }
   }
 

--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/enrich/kinesis/Sink.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/enrich/kinesis/Sink.scala
@@ -13,13 +13,10 @@
 package com.snowplowanalytics.snowplow.enrich.kinesis
 
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import scala.collection.JavaConverters._
-import scala.util.control.NonFatal
 
-import cats.data.Validated
 import cats.implicits._
 import cats.{Monoid, Parallel}
 
@@ -37,7 +34,6 @@ import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.kinesis.model._
 import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder}
 
-import com.snowplowanalytics.snowplow.analytics.scalasdk.Event
 import com.snowplowanalytics.snowplow.enrich.common.fs2.{AttributedByteSink, AttributedData, ByteSink}
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.Output
 import com.snowplowanalytics.snowplow.enrich.common.fs2.io.Retries
@@ -65,7 +61,7 @@ object Sink {
           case Some(region) =>
             for {
               producer <- Resource.eval[F, AmazonKinesis](mkProducer(o, region))
-            } yield records => writeToKinesis(blocker, o, producer, toKinesisRecords(records, o))
+            } yield records => writeToKinesis(blocker, o, producer, toKinesisRecords(records))
           case None =>
             Resource.eval(Sync[F].raiseError(new RuntimeException(s"Region not found in the config and in the runtime")))
         }
@@ -209,24 +205,9 @@ object Sink {
             result.nextBatchAttempt.pure[F]
         }
 
-  private def toKinesisRecords(records: List[AttributedData[Array[Byte]]], config: Output.Kinesis): List[PutRecordsRequestEntry] =
+  private def toKinesisRecords(records: List[AttributedData[Array[Byte]]]): List[PutRecordsRequestEntry] =
     records.map { r =>
-      val sourceData = r.data
-      val binaryData =
-        try if (config.jsonOutput) {
-          val tsv = new String(sourceData)
-          // TODO: Its likely better to handle this in the layer that validates the output size is not exceeded
-          Event.parse(tsv) match {
-            case Validated.Valid(event) => event.toJson(lossy = true).noSpaces.getBytes(StandardCharsets.UTF_8)
-            case Validated.Invalid(_) => sourceData
-          }
-        } else
-          sourceData
-        catch {
-          // TODO: Re-consider what to do when parsing the data fails
-          case NonFatal(_) => sourceData
-        }
-
+      val binaryData = r.data
       val data = ByteBuffer.wrap(binaryData)
       val prre = new PutRecordsRequestEntry()
       prre.setPartitionKey(r.partitionKey)

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/enrich/kinesis/ConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/enrich/kinesis/ConfigSpec.scala
@@ -58,8 +58,7 @@ class ConfigSpec extends Specification with CatsIO {
             io.BackoffPolicy(100.millis, 1.second, None),
             500,
             5242880,
-            None,
-            jsonOutput = false
+            None
           ),
           Some(
             io.Output.Kinesis(
@@ -70,8 +69,7 @@ class ConfigSpec extends Specification with CatsIO {
               io.BackoffPolicy(100.millis, 1.second, None),
               500,
               5242880,
-              None,
-              jsonOutput = false
+              None
             )
           ),
           io.Output.Kinesis(
@@ -82,8 +80,7 @@ class ConfigSpec extends Specification with CatsIO {
             io.BackoffPolicy(100.millis, 1.second, None),
             500,
             5242880,
-            None,
-            jsonOutput = false
+            None
           )
         ),
         io.Concurrency(256, 1),
@@ -165,8 +162,7 @@ class ConfigSpec extends Specification with CatsIO {
             io.BackoffPolicy(100.millis, 1.second, None),
             500,
             5242880,
-            None,
-            jsonOutput = false
+            None
           ),
           None,
           io.Output.Kinesis(
@@ -177,8 +173,7 @@ class ConfigSpec extends Specification with CatsIO {
             io.BackoffPolicy(100.millis, 1.second, None),
             500,
             5242880,
-            None,
-            jsonOutput = false
+            None
           )
         ),
         io.Concurrency(256, 1),

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/enrich/kinesis/ConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/enrich/kinesis/ConfigSpec.scala
@@ -131,7 +131,8 @@ class ConfigSpec extends Specification with CatsIO {
                 UUID.fromString("c5f3a09f-75f8-4309-bec5-fea560f78455"),
                 UUID.fromString("75a13583-5c99-40e3-81fc-541084dfc784")
               )
-            )
+            ),
+            None
           )
         ),
         adaptersSchemas,

--- a/modules/nsq/src/test/scala/com/snowplowanalytics/snowplow/enrich/nsq/ConfigSpec.scala
+++ b/modules/nsq/src/test/scala/com/snowplowanalytics/snowplow/enrich/nsq/ConfigSpec.scala
@@ -129,7 +129,8 @@ class ConfigSpec extends Specification with CatsIO {
                 UUID.fromString("c5f3a09f-75f8-4309-bec5-fea560f78455"),
                 UUID.fromString("75a13583-5c99-40e3-81fc-541084dfc784")
               )
-            )
+            ),
+            None
           )
         ),
         adaptersSchemas,

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/enrich/pubsub/ConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/enrich/pubsub/ConfigSpec.scala
@@ -118,7 +118,8 @@ class ConfigSpec extends Specification with CatsIO {
                 UUID.fromString("c5f3a09f-75f8-4309-bec5-fea560f78455"),
                 UUID.fromString("75a13583-5c99-40e3-81fc-541084dfc784")
               )
-            )
+            ),
+            None
           )
         ),
         adaptersSchemas,


### PR DESCRIPTION
#1 and #4 introduced a feature that allows producing JSON output which had a few drawbacks:
1. The JSON encoding was happening at the module level, which means that we would have to decode the TSV just to produce the JSON.
2. Given that the JSON transformation was being done at the Sink, we couldn't produce BadRows from there, meaning that maxRecordSize config wasn't being checked on the JSON output.
3. Any errors when decoding the TSV would be propagated to the Good output with an error tag which is not ideal, that's what the Bad output is for.

This PR:
- Refactors the process to be handled at the Enrich level.
- Introduces an experimental config entry to enable the JSON output, which can be used by all modules.
- Verifies the maxRecordSize config when producing the JSON output.
- Any errors occurring when producing the JSON output are propagated to the Bad output.
- Improves the overall test coverage for the JSON output support.

Notes:
- Follows up from #1 and #4
- Fixes #16
- Supersedes #125 
