### PR TITLE
Add SkinnyJson format

### DIFF
--- a/config/config.eventbridge.extended.hocon
+++ b/config/config.eventbridge.extended.hocon
@@ -367,6 +367,7 @@
     # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
     # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
     # - BigQueryJson: encodes the output as JSON with the expected time format supported by BigQuery.
+    # - SkinnyJson: encodes just the payload and collector inside a JSON object
     "customOutputFormat": {
       "type": "EventbridgeJson"
 

--- a/config/config.kafka.extended.hocon
+++ b/config/config.kafka.extended.hocon
@@ -263,6 +263,7 @@
     # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
     # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
     # - BigQueryJson: encodes the output as JSON with the expected time format supported by BigQuery.
+    # - SkinnyJson: encodes just the payload and collector inside a JSON object
     # "customOutputFormat": {
     #   "type": "FlattenedJson"
     # }

--- a/config/config.kinesis.extended.hocon
+++ b/config/config.kinesis.extended.hocon
@@ -365,6 +365,7 @@
     # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
     # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
     # - BigQueryJson: encodes the output as JSON with the expected time format supported by BigQuery.
+    # - SkinnyJson: encodes just the payload and collector inside a JSON object
     # "customOutputFormat": {
     #   "type": "FlattenedJson"
     # }

--- a/config/config.nsq.extended.hocon
+++ b/config/config.nsq.extended.hocon
@@ -265,6 +265,7 @@
     # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
     # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
     # - BigQueryJson: encodes the output as JSON with the expected time format supported by BigQuery.
+    # - SkinnyJson: encodes just the payload and collector inside a JSON object
     # "customOutputFormat": {
     #   "type": "FlattenedJson"
     # }

--- a/config/config.pubsub.extended.hocon
+++ b/config/config.pubsub.extended.hocon
@@ -261,6 +261,7 @@
     # - FlattenedJson: encodes the output as JSON, where unstruct_event, contexts and derived_contexts are flattened
     # - EventbridgeJson: encodes the output as JSON with extra details, intended exclusively to use with eventbridge module.
     # - BigQueryJson: encodes the output as JSON with the expected time format supported by BigQuery.
+    # - SkinnyJson: encodes just the payload and collector inside a JSON object
     # "customOutputFormat": {
     #   "type": "FlattenedJson"
     # }

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
@@ -470,6 +470,8 @@ object io {
 
     final case class EventbridgeJson(payload: Boolean, collector: Boolean) extends CustomOutputFormat
 
+    final case object SkinnyJson extends CustomOutputFormat
+
     case class CustomOutputFormatRaw(
       `type`: String,
       payload: Option[Boolean],

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
@@ -491,6 +491,9 @@ object io {
                                   case CustomOutputFormatRaw(tpe, _, _) if tpe equalsIgnoreCase "BigQueryJson" =>
                                     BigQueryJson.asRight
 
+                                  case CustomOutputFormatRaw(tpe, _, _) if tpe equalsIgnoreCase "SkinnyJson" =>
+                                    SkinnyJson.asRight
+
                                   case CustomOutputFormatRaw(tpe, payloadOpt, collectorOtp) if tpe equalsIgnoreCase "EventbridgeJson" =>
                                     EventbridgeJson(
                                       payload = payloadOpt.getOrElse(false),
@@ -499,7 +502,7 @@ object io {
 
                                   case other =>
                                     DecodingFailure(
-                                      s"Custom output format $other is not supported. Possible types are FlattenedJson, BigQueryJson and EventbridgeJson",
+                                      s"Custom output format $other is not supported. Possible types are FlattenedJson, BigQueryJson, EventbridgeJson, or, SkinnyJson",
                                       cur.history
                                     ).asLeft
                                 }

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/utils/JsonOutputUtils.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/utils/JsonOutputUtils.scala
@@ -3,14 +3,68 @@ package com.snowplowanalytics.snowplow.enrich.common.fs2.utils
 import com.snowplowanalytics.snowplow.analytics.scalasdk.Event
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.CustomOutputFormat
 import io.circe.Json
+import io.circe.syntax._
+
+import java.nio.charset.StandardCharsets
+import java.util.Base64
 
 object JsonOutputUtils {
 
   def transformEventToJson(event: Event, outputFormat: CustomOutputFormat): Json =
     outputFormat match {
       case CustomOutputFormat.BigQueryJson => BigQueryEncodingUtils.transformEventToBigQueryJson(event)
-      case CustomOutputFormat.FlattenedJson => event.toJson(lossy = true)
-      case CustomOutputFormat.EventbridgeJson(_, _) => event.toJson(lossy = true)
+      case CustomOutputFormat.FlattenedJson | CustomOutputFormat.EventbridgeJson(_, _) | CustomOutputFormat.SkinnyJson =>
+        event.toJson(lossy = true)
     }
 
+  def serializeEventbridgeEvent(
+    tsv: String,
+    event: Json,
+    payload: Boolean,
+    collector: Boolean
+  ): Json = {
+    lazy val base64TSV = computeBase64Tsv(tsv)
+    lazy val host = computeCollectorValue(event)
+
+    val attachments = List((payload, "payload", () => base64TSV.asJson), (collector, "collector", () => host.asJson))
+
+    attachments.foldLeft(event) { case (current, (include, key, getValue)) =>
+      if (include) current.deepMerge(Map(key -> getValue()).asJson)
+      else current
+    }
+  }
+
+  def serializeSkinnyJsonEvent(tsv: String, event: Json): Json = {
+    lazy val base64TSV = computeBase64Tsv(tsv)
+    lazy val host = computeCollectorValue(event)
+
+    Json.obj(
+      "payload" -> base64TSV.asJson,
+      "collector" -> host.asJson
+    )
+  }
+
+  private def computeBase64Tsv(tsv: String): String = Base64.getEncoder
+    .encodeToString(tsv.getBytes(StandardCharsets.UTF_8))
+
+  private def computeCollectorValue(event: Json): Option[String] =
+    for {
+      headers <- event.hcursor
+                   .downField("contexts_org_ietf_http_header_1")
+                   .as[List[Json]]
+                   .toOption
+
+      hostHeader <- headers.find { header =>
+                      header.hcursor
+                        .downField("name")
+                        .as[String]
+                        .toOption
+                        .contains("Host")
+                    }
+
+      host <- hostHeader.hcursor
+                .downField("value")
+                .as[String]
+                .toOption
+    } yield host
 }

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/EnrichSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/EnrichSpec.scala
@@ -368,115 +368,23 @@ class EnrichSpec extends Specification with CatsIO with ScalaCheck {
     }
 
     "serialize a good event to the good output (json format)" in {
-      val ee = new EnrichedEvent {
-        collector_tstamp = "2011-12-03T10:15:30"
-        event_id = "236392af-ffec-4def-a0de-86929e9615be"
-        v_collector = "test"
-        v_etl = "test"
-      }
-
-      TestEnvironment.make(Stream.empty).use { test =>
-        val env = test.env.copy(
-          customOutputFormat = Some(CustomOutputFormat.FlattenedJson)
-        )
-        for {
-          _ <- sinkGood(env, ee)
-          good <- test.good
-          pii <- test.pii
-          bad <- test.bad
-        } yield {
-          (good.size must_== 1)
-          (bad should be empty)
-          (pii should be empty)
-
-          val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
-          (jsonE.isRight should beTrue)
-        }
-      }
+      val format = CustomOutputFormat.FlattenedJson
+      simpleCustomFormatTest(format)
     }
 
     "serialize a good event to the good output (bigquery json format)" in {
-      val ee = new EnrichedEvent {
-        collector_tstamp = "2011-12-03T10:15:30"
-        event_id = "236392af-ffec-4def-a0de-86929e9615be"
-        v_collector = "test"
-        v_etl = "test"
-      }
-
-      TestEnvironment.make(Stream.empty).use { test =>
-        val env = test.env.copy(
-          customOutputFormat = Some(CustomOutputFormat.BigQueryJson)
-        )
-        for {
-          _ <- sinkGood(env, ee)
-          good <- test.good
-          pii <- test.pii
-          bad <- test.bad
-        } yield {
-          (good.size must_== 1)
-          (bad should be empty)
-          (pii should be empty)
-
-          val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
-          (jsonE.isRight should beTrue)
-        }
-      }
+      val format = CustomOutputFormat.BigQueryJson
+      simpleCustomFormatTest(format)
     }
 
     "serialize a good event to the good output (skinny json format)" in {
-      val ee = new EnrichedEvent {
-        collector_tstamp = "2011-12-03T10:15:30"
-        event_id = "236392af-ffec-4def-a0de-86929e9615be"
-        v_collector = "test"
-        v_etl = "test"
-      }
-
-      TestEnvironment.make(Stream.empty).use { test =>
-        val env = test.env.copy(
-          customOutputFormat = Some(CustomOutputFormat.SkinnyJson)
-        )
-        for {
-          _ <- sinkGood(env, ee)
-          good <- test.good
-          pii <- test.pii
-          bad <- test.bad
-        } yield {
-          (good.size must_== 1)
-          (bad should be empty)
-          (pii should be empty)
-
-          val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
-          (jsonE.isRight should beTrue)
-        }
-      }
+      val format = CustomOutputFormat.SkinnyJson
+      simpleCustomFormatTest(format)
     }
 
     "serialize a good event to the good output (eventbridge format)" in {
-      val ee = new EnrichedEvent {
-        collector_tstamp = "2011-12-03T10:15:30"
-        event_id = "236392af-ffec-4def-a0de-86929e9615be"
-        v_collector = "test"
-        v_etl = "test"
-      }
-
-      TestEnvironment.make(Stream.empty).use { test =>
-        val env = test.env.copy(
-          customOutputFormat = Some(CustomOutputFormat.EventbridgeJson(payload = false, collector = false))
-        )
-        for {
-          _ <- sinkGood(env, ee)
-          good <- test.good
-          pii <- test.pii
-          bad <- test.bad
-        } yield {
-          (good.size must_== 1)
-          (bad should be empty)
-          (pii should be empty)
-
-          val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
-          (jsonE.isRight should beTrue)
-        }
-      }
+      val format = CustomOutputFormat.EventbridgeJson(payload = false, collector = false)
+      simpleCustomFormatTest(format)
     }
 
     "serialize a good event to the good output (eventbridge format with payload)" in {
@@ -853,6 +761,32 @@ class EnrichSpec extends Specification with CatsIO with ScalaCheck {
           (bad should be empty)
           (pii should be empty)
         }
+      }
+    }
+  }
+
+  private def simpleCustomFormatTest(format: CustomOutputFormat) = {
+    val ee = new EnrichedEvent {
+      collector_tstamp = "2011-12-03T10:15:30"
+      event_id = "236392af-ffec-4def-a0de-86929e9615be"
+      v_collector = "test"
+      v_etl = "test"
+    }
+
+    TestEnvironment.make(Stream.empty).use { test =>
+      val env = test.env.copy(customOutputFormat = Some(format))
+      for {
+        _ <- sinkGood(env, ee)
+        good <- test.good
+        pii <- test.pii
+        bad <- test.bad
+      } yield {
+        (good.size must_== 1)
+        (bad should be empty)
+        (pii should be empty)
+
+        val jsonE = _root_.io.circe.parser.parse(new String(good.head.data))
+        (jsonE.isRight should beTrue)
       }
     }
   }


### PR DESCRIPTION
This is similar to the EventbridgeJson in the sense that we keep the collector and the payload, on the other hand, everything else is drop.

For example, an output from this format would be:
- { "collector": "...", "payload": "..." }