### PR TITLE
Bump scalacenter/sbt-dependency-submission action to v3

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: scalacenter/sbt-dependency-submission@v2
+      - uses: scalacenter/sbt-dependency-submission@v3
         with:
           ## Optional: Define the working directory of your build.
           ## It should contain the build.sbt file.


### PR DESCRIPTION
in order to include explicit sbt installation step to the Update Dependency Graph pipeline