### PR TITLE
Drop unnecessary and discontinued coursier cache action. 

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,7 +11,7 @@ jobs:
     name: Update Dependency Graph
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/lacework.yml
+++ b/.github/workflows/lacework.yml
@@ -12,14 +12,12 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: coursier/cache-action@v3
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: 'corretto'
 
       - name: Get current version
         id: ver

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: coursier/cache-action@v6
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: 'corretto'
+          cache: sbt
       - name: Install sbt
         run: |
           echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
@@ -80,7 +80,6 @@ jobs:
         if: startsWith(github.ref, 'refs/heads/snapshot')
         with:
           fetch-depth: 0
-      - uses: coursier/cache-action@v6
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: coursier/cache-action@v6
     - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
SBT dependencies caching is enabled in setup-java action

<!--
Thank you for contributing to Opensnowcat Enrich!

You'll find a small checklist below which should help speed up the review process:

- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
- [ ] Is your pull request against the `master` branch?
-->
