### PR TITLE
Upgrade log4j to 2.25.4 in order to patch CVE-2026-34478, CVE-2026-34…

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,10 +45,10 @@ object Dependencies {
     val jsonsmart = "2.5.2"
     val iabClient = "0.2.0"
     val yauaa = "7.24.0"
-    val log4jToSlf4j = "2.25.3"
+    val log4jToSlf4j = "2.25.4"
+    val log4j = "2.25.4"
     val guava = "33.2.1-jre"
     val slf4j = "2.0.13"
-    val log4j = "2.25.3"
     val thrift = "0.20.0"
     val sprayJson = "1.3.6"
     val netty = "4.1.132.Final"
@@ -242,6 +242,7 @@ object Dependencies {
       iabClient,
       yauaa,
       log4jToSlf4j,
+      log4j,
       guava,
       circeOptics,
       circeJackson,
@@ -357,7 +358,6 @@ object Dependencies {
       fs2BlobS3,
       fs2BlobGcs,
       grpcNettyShaded,
-      log4j, // for security vulnerabilities
       specs2,
       specs2CE
     )


### PR DESCRIPTION
…480, CVE-2026-34477. Move log4j to common module dependencies.

<!--
Thank you for contributing to Opensnowcat Enrich!

You'll find a small checklist below which should help speed up the review process:

- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
- [ ] Is your pull request against the `master` branch?
-->
